### PR TITLE
Provide CNL Git tag parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,25 @@ message("-- INT128 = ${INT128}")
 message("-- STD = ${STD}")
 message("-- EXCEPTIONS = ${EXCEPTIONS}")
 
+set(CNL_GIT_TAG_DEFAULT 3ce341aeec25204f84d3662cd1abed7f9df015ff)
+set(CNL_GIT_TAG_ENV $ENV{CDSP_CNL_GIT_TAG})
+set(CNL_GIT_TAG "" CACHE BOOL "specify which revision of CNL to use")
+
+if (CNL_GIT_TAG_ENV)
+    set(CNL_GIT_TAG "${CNL_GIT_TAG_ENV}")
+    message("Using CNL tag, ${CNL_GIT_TAG}, from environment variable, `CDSP_CNL_GIT_TAG`.")
+elseif (CNL_GIT_TAG)
+    message("Using CNL tag, ${CNL_GIT_TAG}, from CMake configuration `CNL_GIT_TAG`.")
+else ()
+    set(CNL_GIT_TAG "${CNL_GIT_TAG_DEFAULT}")
+    message("Using CNL tag, ${CNL_GIT_TAG}, from project default, `CNL_GIT_TAG_DEFAULT`.")
+endif ()
+
 ExternalProject_Add(
         Cnl
         PREFIX ${CMAKE_BINARY_DIR}/Cnl
         GIT_REPOSITORY "https://github.com/johnmcfarlane/cnl.git"
-        GIT_TAG "3ce341aeec25204f84d3662cd1abed7f9df015ff"
+        GIT_TAG "${CNL_GIT_TAG}"
         GIT_PROGRESS 1
         CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER} -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER} -DCMAKE_INSTALL_PREFIX=${Cnl_DESTDIR} -DINT128=${INT128} -DSTD=${STD} -DEXCEPTIONS=${EXCEPTIONS}
 )


### PR DESCRIPTION
- allows user to override version of CNL chosen via CMake config
  or environment variable